### PR TITLE
Default bundle.js to utf-8 encoding

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -36,7 +36,7 @@ var server = http.createServer(function (req, res) {
         res.end('<html><body><script src="/bundle.js"></script></body></html>');
     }
     else if (req.url === '/bundle.js') {
-        res.setHeader('content-type', 'application/javascript');
+        res.setHeader('content-type', 'application/javascript; charset=utf-8;');
         res.end(prelude + '\n' + src);
     }
 });


### PR DESCRIPTION
I wanna run [caolan/forms validator tests](https://github.com/caolan/forms/blob/master/test/test-validators.js#L73) in testling, but some of the test data is unicode.  Boom.  

Adding an encoding to content-type header fixed up my problem.  It might make sense for the encoding to be configurable, but I'd wait for someone to make noise before adding the complexity.
