### PR TITLE
list bundled browser-launcher as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "bouncy": "~3.2.2",
-        "browser-launcher": "~1.0.1",
+        "browser-launcher": "~1.0.2",
         "browserify": "3.x.x",
         "concat-stream": "~1.6.2",
         "ecstatic": "~0.4.13",


### PR DESCRIPTION
`npm install && npm ls` yields

```
npm ERR! extraneous: browser-launcher@0.2.0 testling/node_modules/browser-launcher
```

@isaacs suggests that [bundled dependencies still need to be regular dependencies](https://github.com/mikeal/request/issues/313#issuecomment-8265326).
